### PR TITLE
CHIP-0008: Splitter Puzzle

### DIFF
--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -123,13 +123,47 @@ Using the above scheme as an example, it looks like this:
 ((0x3816a97150946c7745457f45a4fed6c16890637847b2df95f383e439758732d7 80) (0x09731fc56bff8031dc9a16f60dcb6f6462960cd76d4b5233dd5bc21697d7fca7 20)
 ```
 
-The only solution parameter needed on spend is the actual amount of the coin.
+The only solution parameter needed on spend is the actual amount of the coin and the total number of shares. The total number of shares is defined as the sum of all individual shares in the scheme.
 
-On spend, the puzzle steps through the entries of the `PAYOUT_SCHEME` and creates a new coin per entry. The amount of the new coins will be a share of the total amount, determined by the share defined in the `PAYOUT_SCHEME`. The total number of shares is defined as the  sum of all individual shares in the scheme and will be calculated by the puzzle.
+The puzzle is very flexible and doesn't require a specific number of shares.
+This means the following share distributions are equivalent:
 
-This means the share distributions `(1,1)` and `(50,50)` and `(5000, 5000)` are equivalent.
+| Recipient Address                                              | Share      |
+| :------------------------------------------------------------- | :--------- |
+| xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsfmtqfp | 4          |
+| xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljns4uw464 | 1          |
+
+is equivalent to
+
+| Recipient Address                                              | Share      |
+| :------------------------------------------------------------- | :--------- |
+| xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsfmtqfp | 80         |
+| xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljns4uw464 | 20         |
+
+is equivalent to
+
+| Recipient Address                                              | Share      |
+| :------------------------------------------------------------- | :--------- |
+| xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsfmtqfp | 8000       |
+| xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljns4uw464 | 2000       |
+
+This gives the creator of the puzzle a lot of flexibility on how to split the coin.
+
+On spend, the puzzle steps through the entries of the `PAYOUT_SCHEME` and creates a new coin per entry. The amount of the new coins will be a share of the total amount, determined by the share defined in the `PAYOUT_SCHEME` and the total number of shares. 
 
 If the created coins do not use up the full coin amount, the rest is added to the last recipient in the payout scheme. This difference is at most NUMBER_OF_RECIPIENTS mojos, therefore its not worth the effort to construct a more complicated mechanism. It is important that the full coin amount is being reissued, otherwise it breaks CAT coins.
+
+Here are some example coin splits for the above schema
+
+| Coin Amount | Recipient 1 receives | Recipient 2 receives |
+| :---------- | :------------------- | :------------------- |
+| 1 mojos     | 0 mojos              | 1 mojos              |
+| 2 mojos     | 1 mojos              | 1 mojos              |
+| 100 mojos   | 80 mojos             | 20 mojos             |
+| 101 mojos   | 80 mojos             | 21 mojos             |
+| 102 mojos   | 81 mojos             | 21 mojos             |
+| 1000 mojos  | 800 mojos            | 200 mojos            |
+| 1001 mojos  | 800 mojos            | 201 mojos            |
 
 ## Test Cases
 
@@ -150,6 +184,10 @@ Potential risks:
 
 - Royalty recipient can be altered
   - The royalty recipients are curried into the puzzle and the only parameter in the solution is the amount. So the payout scheme can not be altered after it has been created.
+- Puzzle can be bricked by wrong configuration
+  - Due to the dynamic share calculation, any payout scheme with positive integers as shares will work fine.
+  - The nature of Chialisp is that the puzzle will only execute and check the validity of the payout scheme when spending the coin. This is too late to detect any configuration errors, so the tools constructing the puzzle have to make sure that the payout scheme adheres to the defined format.
+  - The puzzle does not support negative shares or fractional shares and will behave in undefined ways if configured that way.
 - Royalty payout can be stalled
   - Since the royalty payment can be triggered by any party on a permissionless blockchain, nobody can stall or prevent this. 
 - Info to construct split puzzle can get lost

--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -5,7 +5,7 @@
 | Author       | [Andreas Greimel](https://github.com/greimela) ([@acevail\_](https://twitter.com/acevail_) on Twitter) |
 | Editor       | [Dan Perry](https://github.com/danieljperry)                                                           |
 | Comments-URI | https://github.com/Chia-Network/chips/pull/30                                                          |
-| Status       | Last Call                                                                                                  |
+| Status       | Final                                                                                                  |
 | Category     | Informational                                                                                          |
 | Sub-Category | Informative                                                                                            |
 | Created      | 2022-09-03                                                                                             |

--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -5,7 +5,7 @@
 | Author       | [Andreas Greimel](https://github.com/greimela) ([@acevail\_](https://twitter.com/acevail_) on Twitter) |
 | Editor       | [Dan Perry](https://github.com/danieljperry)                                                           |
 | Comments-URI | https://github.com/Chia-Network/chips/pull/30                                                          |
-| Status       | Draft                                                                                                  |
+| Status       | Review                                                                                                  |
 | Category     | Informational                                                                                          |
 | Sub-Category | Informative                                                                                            |
 | Created      | 2022-09-03                                                                                             |

--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -141,7 +141,7 @@ On spend, the puzzle steps through the entries of the `PAYOUT_SCHEME` and create
 
 This means the share distributions `(1,1)` and `(50,50)` and `(5000, 5000)` are equivalent.
 
-If the created coins do not use up the full coin amount, the rest is added to the last recipient in the payout scheme. This difference is at most 1 mojo, therefore its not worth the effort to construct a more complicated mechanism. It is important that the full coin amount is being reissued, otherwise it breaks CAT coins.
+If the created coins do not use up the full coin amount, the rest is added to the last recipient in the payout scheme. This difference is at most NUMBER_OF_RECIPIENTS mojos, therefore its not worth the effort to construct a more complicated mechanism. It is important that the full coin amount is being reissued, otherwise it breaks CAT coins.
 
 ## Test Cases
 

--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -1,19 +1,19 @@
 | CHIP Number  | < Creator must leave this blank. Editor will assign a number.>                                         |
 | :----------- | :----------------------------------------------------------------------------------------------------- |
-| Title        | Split Royalties for NFT1                                                                               |
-| Description  | A standard for splitting royalties for NFT1-compliant NFTs on Chia's blockchain                        |
+| Title        | Splitter Puzzle                                                                                        |
+| Description  | A standard puzzle for splitting a coin according to a predefined splitting schema.                     |
 | Author       | [Andreas Greimel](https://github.com/greimela) ([@acevail\_](https://twitter.com/acevail_) on Twitter) |
-| Editor       | [Dan Perry](https://github.com/danieljperry)
+| Editor       | [Dan Perry](https://github.com/danieljperry)                                                           |
 | Comments-URI | https://github.com/Chia-Network/chips/pull/30                                                          |
 | Status       | Draft                                                                                                  |
-| Category     | Process                                                                                                |
-| Sub-Category | Procedural                                                                                             |
+| Category     | Informational                                                                                          |
+| Sub-Category | Informative                                                                                            |
 | Created      | 2022-09-03                                                                                             |
 | Dependencies | None                                                                                                   |
 
 ## Abstract
 
-This proposal aims to define a standard for splitting royalties for NFT1-compliant NFTs, using a standard Chialisp puzzle to prevent marketplace lock-in.
+This proposal aims to define a standard puzzle for splitting a coin according to a predefined splitting schema
 
 ## Motivation
 
@@ -22,8 +22,6 @@ It is very flexible, since any address and therefore any puzzle can be used as r
 Many people in the community have requested the option to split the royalty payment between different recipients.
 For example, a share should be sent to a charity, or multiple artists want to share the royalties automatically.
 Having this features available increases the value of the Chia NFT ecosystem as a whole.
-
-Due to the nature of the Coinset model, the royalty split has to be triggered by some off-chain entity. This proposal ensures to ensure independence from any individual actor.
 
 ## Backwards Compatibility
 
@@ -37,15 +35,7 @@ The solution outlined in this propsal ensures independence from any single actor
 
 The core is a simple Chialisp puzzle without many moving parts. It includes a payout scheme defining how the royalty should be split. The payment scheme is fixed and can not be altered by third parties. Anyone is able to trigger the royalty payout for any NFT.
 
-In order to allow obervers to spend a royalty split coin, this proposal contains an extension to the NFT on-chain metadata to include the royalty payout scheme. This allows observers to recreate the royalty puzzle and optionally spend it.
-
-An alternative approach would be to include the royalty payout scheme in the off-chain metadata instead. This was dismissed since it would require an observer to fetch the off-chain metadata as well to be able to trigger the split, which increases the complexity and reduces the permanence. Relying solely on on-chain metadata ensures the royalty split can always be reconstructed.
-
 ## Specification
-
-This specification has two parts.
-The Chialisp puzzle that splits itself into one or multiple smaller coins, according to a predefined payout scheme.
-And an addition to the NFT metadata, to allow obervers to figure out the royalty puzzle and optionally spend it.
 
 An example payout scheme could look like this
 
@@ -54,14 +44,12 @@ An example payout scheme could look like this
 | xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsfmtqfp | 80         |
 | xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljns4uw464 | 20         |
 
-### Royalty Split Chialisp Puzzle
-
 The proposed Chialisp puzzle looks like this.
 
 ```
 (mod (PAYOUT_SCHEME my_amount)
 
-  (include condition_codes.clvm)
+  (include condition_codes.clib)
   (include curry-and-treehash.clinc)
 
   (defun-inline calculate_share (total_amount share total_shares)
@@ -76,18 +64,32 @@ The proposed Chialisp puzzle looks like this.
     (f payout_scheme_item)
   )
 
-   ; Loop through the royalty payout scheme and create coins
-  (defun split_amount_and_create_coins (PAYOUT_SCHEME total_amount total_shares)
-    (if PAYOUT_SCHEME
-      (c
+  (defun-inline ignore_zero_amount (condition)
+    (if (> (f (r (r condition))) 0)
+      condition
+      ()
+    )
+  )
+
+   ; Loop through the payout scheme and create coins
+  (defun split_amount_and_create_coins (PAYOUT_SCHEME total_amount total_shares remaining_amount)
+    (c
+      (ignore_zero_amount 
         (list
           CREATE_COIN
           (get_puzhash (f PAYOUT_SCHEME))
-          (get_amount (f PAYOUT_SCHEME) total_amount total_shares)
+          (if (r PAYOUT_SCHEME) (get_amount (f PAYOUT_SCHEME) total_amount total_shares) remaining_amount)
         )
-        (split_amount_and_create_coins (r PAYOUT_SCHEME) total_amount total_shares)
       )
-      ()
+      (if (r PAYOUT_SCHEME)
+        (split_amount_and_create_coins 
+          (r PAYOUT_SCHEME) 
+          total_amount 
+          total_shares 
+          (- remaining_amount (get_amount (f PAYOUT_SCHEME) total_amount total_shares))
+        )
+        ()
+      )
     )
   )
 
@@ -102,18 +104,32 @@ The proposed Chialisp puzzle looks like this.
     )
   )
 
+  ; remove empty () members
+  (defun squish (the_list)
+    (if (l the_list)
+      (if (not (l (f the_list)))
+        (squish (r the_list))
+        (c
+          (f the_list)
+          (squish (r the_list))
+        )
+      )
+      ()
+    )
+  )
+
   ; main
   (c
     (list CREATE_COIN_ANNOUNCEMENT my_amount)
     (c
       (list ASSERT_MY_AMOUNT my_amount)
-      (split_amount_and_create_coins PAYOUT_SCHEME my_amount (count_shares PAYOUT_SCHEME))
+      (squish (split_amount_and_create_coins PAYOUT_SCHEME my_amount (count_shares PAYOUT_SCHEME) my_amount))
     )
   )
 )
 ```
 
-The royalty payout scheme `PAYOUT_SCHEME` is curried into this puzzle, to make it immutable. 
+The payout scheme `PAYOUT_SCHEME` is curried into this puzzle, to make it immutable. 
 Using the above scheme as an example, it looks like this:
 ```
 ((0x3816a97150946c7745457f45a4fed6c16890637847b2df95f383e439758732d7 80) (0x09731fc56bff8031dc9a16f60dcb6f6462960cd76d4b5233dd5bc21697d7fca7 20)
@@ -125,43 +141,20 @@ On spend, the puzzle steps through the entries of the `PAYOUT_SCHEME` and create
 
 This means the share distributions `(1,1)` and `(50,50)` and `(5000, 5000)` are equivalent.
 
-If the created coins do not use up the full coin amount, the rest is left for the farmer of the block. This difference is most likely very small and not worth the effort to construct a more complex puzzle to collect this rest.
-
-### NFT Metadata
-
-The second part is an addition to the NFT metadata.
-In order to allow any observer to recreate the split royalty puzzle and trigger the split, the observer has to know the payout scheme.
-
-The suggested format is a list of 2-tuples, each containing an address and the share of the royalties it should receive. The total number of shares is the sum of all individual shares in the list.
-
-```typescript
-{
-  // existing metadata
-  "rs": Array<[string, number]>
-}
-```
-
-The royalty payout example from above would look like this:
-
-```typescript
-{
-  //existing metadata
-  "rs": [
-    ["xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsfmtqfp", 80],
-    ["xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljns4uw464", 20]
-  ]
-}
-```
+If the created coins do not use up the full coin amount, the rest is added to the last recipient in the payout scheme. This difference is at most 1 mojo, therefore its not worth the effort to construct a more complicated mechanism. It is important that the full coin amount is being reissued, otherwise it breaks CAT coins.
 
 ## Test Cases
 
-The unit test for the royalty split Chialisp puzzle is located in the `royalty_split` branch of the `greimela/chia-blockchain` GitHub repository: [tests/wallet/nft_wallet/test_nft_puzzles.py](https://github.com/greimela/chia-blockchain/blob/royalty_split/tests/wallet/nft_wallet/test_nft_puzzles.py).
+The unit test for the split Chialisp puzzle is located in the `greimela/chialisp` GitHub repository: [royalty_share/tests/test_p2_royalty_share_arbitrary_shares.py](https://github.com/greimela/chialisp/blob/main/royalty_share/tests/test_p2_royalty_share_arbitrary_shares.py).
 
-A more extensive integration test using NFT offers can be found here: [tests/wallet/nft_wallet/test_nft_royalty_split.clvm](https://github.com/greimela/chia-blockchain/blob/royalty_split/tests/wallet/nft_wallet/test_nft_royalty_split.py).
+<!-- A more extensive integration test using NFT offers can be found here: [tests/wallet/nft_wallet/test_nft_royalty_split.clvm](https://github.com/greimela/chia-blockchain/blob/royalty_split/tests/wallet/nft_wallet/test_nft_royalty_split.py). -->
 
 ## Reference Implementation
 
-The Chialisp puzzle itself is located in the `royalty_split` branch of the `greimela/chia-blockchain` GitHub repository: [chia/wallet/puzzles/royalty_split.clvm](https://github.com/greimela/chia-blockchain/blob/royalty_split/chia/wallet/puzzles/royalty_split.clvm).
+The Chialisp puzzle itself is located in the `greimela/chialisp` GitHub repository: [royalty_share/clsp/p2_royalty_share_arbitrary_shares/p2_royalty_share_arbitrary_shares_rest_to_last.clsp](https://github.com/greimela/chialisp/blob/main/royalty_share/clsp/p2_royalty_share_arbitrary_shares/p2_royalty_share_arbitrary_shares_rest_to_last.clsp).
+
+This repository is a fork of the Chialisp repository by @trgarrett, which already contains some driver code for this and other royalty puzzles.
+The plan is to unify all those royalty puzzles into one standard.
 
 ## Security
 
@@ -173,11 +166,8 @@ Potential risks:
   - The royalty recipients are curried into the puzzle and the only parameter in the solution is the amount. So the payout scheme can not be altered after it has been created.
 - Royalty payout can be stalled
   - Since the royalty payment can be triggered by any party on a permissionless blockchain, nobody can stall or prevent this. 
-- Info to construct royalty puzzle can get lost
-  - The payout scheme is added to the NFT on-chain metadata, so it can not get lost as long as the Chia blockchain lives.
-- Users can be deceived by a mismatch between the NFT metadata and the actual royalty puzzle
-  - A malicious actor could specifiy in the NFT metadata that a large share of the royalties is given to some charity. The actor could then use a different royalty puzzle that sends all royalties to himself.
-  - Mitigation: Marketplaces and blockchain explorers should check whether the payout scheme defined in the NFT metadata matches the royalty puzzle.
+- Info to construct split puzzle can get lost
+  - As soon as one particular split occurs for the first time, the puzzle is stored on the blockchain. Also, it is in the best interest of recipients of the split to store the payout scheme in order to get paid in the future.
 
 ## Additional Assets
 

--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -3,6 +3,7 @@
 | Title        | Split Royalties for NFT1                                                                               |
 | Description  | A standard for splitting royalties for NFT1-compliant NFTs on Chia's blockchain                        |
 | Author       | [Andreas Greimel](https://github.com/greimela) ([@acevail\_](https://twitter.com/acevail_) on Twitter) |
+| Editor       | [Dan Perry](https://github.com/danieljperry)
 | Comments-URI | https://github.com/Chia-Network/chips/pull/30                                                          |
 | Status       | Draft                                                                                                  |
 | Category     | Process                                                                                                |

--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -3,8 +3,8 @@
 | Title        | Split Royalties for NFT1                                                                               |
 | Description  | A standard for splitting royalties for NFT1-compliant NFTs on Chia's blockchain                        |
 | Author       | [Andreas Greimel](https://github.com/greimela) ([@acevail\_](https://twitter.com/acevail_) on Twitter) |
-| Comments-URI | < Creator must leave this blank. Editor will assign a URI.>                                            |
-| Status       | < Creator must leave this blank. Editor will assign a status.>                                         |
+| Comments-URI | https://github.com/Chia-Network/chips/pull/30                                                          |
+| Status       | Draft                                                                                                  |
 | Category     | Process                                                                                                |
 | Sub-Category | Procedural                                                                                             |
 | Created      | 2022-09-03                                                                                             |

--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -5,7 +5,7 @@
 | Author       | [Andreas Greimel](https://github.com/greimela) ([@acevail\_](https://twitter.com/acevail_) on Twitter) |
 | Editor       | [Dan Perry](https://github.com/danieljperry)                                                           |
 | Comments-URI | https://github.com/Chia-Network/chips/pull/30                                                          |
-| Status       | Review                                                                                                  |
+| Status       | Last Call                                                                                                  |
 | Category     | Informational                                                                                          |
 | Sub-Category | Informative                                                                                            |
 | Created      | 2022-09-03                                                                                             |

--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -91,6 +91,7 @@ The proposed Chialisp puzzle looks like this.
     )
   )
 
+  ; calculate the sum of all shares to later determine the share of each participant
   (defun count_shares (PAYOUT_SCHEME)
     (if PAYOUT_SCHEME
       (+

--- a/CHIPs/chip-0008.md
+++ b/CHIPs/chip-0008.md
@@ -13,7 +13,7 @@
 
 ## Abstract
 
-This proposal aims to define a standard puzzle for splitting a coin according to a predefined splitting schema
+This proposal aims to define a standard puzzle for splitting a coin according to a predefined splitting schema.
 
 ## Motivation
 
@@ -47,83 +47,71 @@ An example payout scheme could look like this
 The proposed Chialisp puzzle looks like this.
 
 ```
-(mod (PAYOUT_SCHEME my_amount)
+; This puzzle is designed to split its coin amount according to a predefined payout scheme.
+
+(mod
+  (
+  PAYOUT_SCHEME ; The payout scheme is a list of recipient puzzle hashes and their share, e.g.
+                ; ((0xcafef00d 80) (0xdeadbeef 20)) for an 80/20 split
+  my_amount ; The amount of the coin to be split.
+  total_shares ; The sum of all shares in the payout scheme. Passed in to reduce the complexity of the puzzle.
+  )
 
   (include condition_codes.clib)
-  (include curry-and-treehash.clinc)
+  (include curry_and_treehash.clib)
+
+  (defun-inline get_puzhash (payout_scheme_item)
+    (f payout_scheme_item)
+  )
+
+  (defun-inline get_share (payout_scheme_item)
+    (f (r payout_scheme_item))
+  )
 
   (defun-inline calculate_share (total_amount share total_shares)
     (f (divmod (* total_amount share) total_shares))
   )
 
   (defun-inline get_amount (payout_scheme_item total_amount total_shares)
-    (calculate_share total_amount (f (r payout_scheme_item)) total_shares)
+    (calculate_share total_amount (get_share payout_scheme_item) total_shares)
   )
 
-  (defun-inline get_puzhash (payout_scheme_item)
-    (f payout_scheme_item)
-  )
-
-  (defun-inline ignore_zero_amount (condition)
-    (if (> (f (r (r condition))) 0)
-      condition
-      ()
-    )
-  )
-
-   ; Loop through the payout scheme and create coins
-  (defun split_amount_and_create_coins (PAYOUT_SCHEME total_amount total_shares remaining_amount)
-    (c
-      (ignore_zero_amount 
-        (list
-          CREATE_COIN
-          (get_puzhash (f PAYOUT_SCHEME))
-          (if (r PAYOUT_SCHEME) (get_amount (f PAYOUT_SCHEME) total_amount total_shares) remaining_amount)
-        )
-      )
-      (if (r PAYOUT_SCHEME)
-        (split_amount_and_create_coins 
-          (r PAYOUT_SCHEME) 
-          total_amount 
-          total_shares 
-          (- remaining_amount (get_amount (f PAYOUT_SCHEME) total_amount total_shares))
-        )
-        ()
-      )
-    )
-  )
-
-  ; calculate the sum of all shares to later determine the share of each participant
-  (defun count_shares (PAYOUT_SCHEME)
+  ; mutual recursive function to calculate the amount only once
+  (defun calculate_amount_and_split (PAYOUT_SCHEME total_amount total_shares shares_sum remaining_amount)
     (if PAYOUT_SCHEME
-      (+
-        (f (r (f PAYOUT_SCHEME)))
-        (count_shares (r PAYOUT_SCHEME))
+      (split_amount_and_create_coins PAYOUT_SCHEME (get_amount (f PAYOUT_SCHEME) total_amount total_shares) total_amount total_shares shares_sum remaining_amount)
+      (if (= total_shares shares_sum)
+        ()
+        (x) ; raise if total shares input doesn't match the sum of all shares
       )
-      0
     )
   )
 
-  ; remove empty () members
-  (defun squish (the_list)
-    (if (l the_list)
-      (if (not (l (f the_list)))
-        (squish (r the_list))
-        (c
-          (f the_list)
-          (squish (r the_list))
-        )
+   ; Loop through the royalty payout scheme and create coins
+  (defun split_amount_and_create_coins (PAYOUT_SCHEME this_amount total_amount total_shares shares_sum remaining_amount)
+    (c
+      (list
+        CREATE_COIN
+        (get_puzhash (f PAYOUT_SCHEME))
+        (if (r PAYOUT_SCHEME) this_amount remaining_amount)
+        (list (get_puzhash (f PAYOUT_SCHEME)))
       )
-      ()
+      (calculate_amount_and_split
+        (r PAYOUT_SCHEME)
+        total_amount
+        total_shares
+        (+ shares_sum (get_share (f PAYOUT_SCHEME)))
+        (- remaining_amount this_amount)
+      )
     )
   )
 
   ; main
   (c
-    (list CREATE_COIN_ANNOUNCEMENT my_amount)
+    (list CREATE_COIN_ANNOUNCEMENT ())
     (c
       (list ASSERT_MY_AMOUNT my_amount)
-      (squish (split_amount_and_create_coins PAYOUT_SCHEME my_amount (count_shares PAYOUT_SCHEME) my_amount))
+      (calculate_amount_and_split PAYOUT_SCHEME my_amount total_shares 0 my_amount)
     )
   )
 )
@@ -146,8 +134,6 @@ If the created coins do not use up the full coin amount, the rest is added to th
 ## Test Cases
 
 The unit test for the split Chialisp puzzle is located in the `greimela/chialisp` GitHub repository: [royalty_share/tests/test_p2_royalty_share_arbitrary_shares.py](https://github.com/greimela/chialisp/blob/main/royalty_share/tests/test_p2_royalty_share_arbitrary_shares.py).
-
-<!-- A more extensive integration test using NFT offers can be found here: [tests/wallet/nft_wallet/test_nft_royalty_split.clvm](https://github.com/greimela/chia-blockchain/blob/royalty_split/tests/wallet/nft_wallet/test_nft_royalty_split.py). -->
 
 ## Reference Implementation
 

--- a/CHIPs/chip-XXXX.md
+++ b/CHIPs/chip-XXXX.md
@@ -52,9 +52,10 @@ And an addition to the NFT metadata, to allow obervers to figure out the royalty
 
 An example payout scheme could look like this
 
-| Recipient Address | Share in % |
-| xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsyuvkgj | 80 |
-| xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljnscmfrmx | 20 |
+| Recipient Address                                              | Share in % |
+|:---------------------------------------------------------------|:-----------|
+| xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsyuvkgj | 80         |
+| xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljnscmfrmx | 20         |
 
 ### Royalty Split Chialisp Puzzle
 
@@ -105,14 +106,14 @@ The proposed Chialisp puzzle looks like this.
 
 The royalty payout scheme `ROYALTY_LIST` is curried into this puzzle, to make it immutable. The only solution parameter needed on spend is the actual amount of the coin.
 
-On spend, the puzzle steps through the entries of the `ROYALTY_LIST` and creates a new coin per entry. The amount of the new coins will be a share of the total amount, determined by the share defined in the `ROYALTY_LIST`.
+On spend, the puzzle steps through the entries of the `ROYALTY_LIST` and creates a new coin per entry. The amount of the new coins will be a share of the total amount, determined by the share defined in the `ROYALTY_LIST`. The payout share is specified in the same format as NFT royalties, which is `int(percentage * 100)`.
 
 ### NFT Metadata
 
 The second part is an addition to the NFT metadata.
 In order to allow any observer to recreate the split royalty puzzle and trigger the split, the observer has to know the payout scheme.
 
-The suggested format is a list of 2-tuples, each containing an address and the percentage of the royalties it should receive, multiplied by 100
+The suggested format is a list of 2-tuples, each containing an address and the percentage of the royalties it should receive, multiplied by 100.
 
 ```typescript
 {
@@ -123,7 +124,7 @@ The suggested format is a list of 2-tuples, each containing an address and the p
 
 The royalty payout example from above would look like this:
 
-```json
+```typescript
 {
   //existing metadata
   "rs": [

--- a/CHIPs/chip-XXXX.md
+++ b/CHIPs/chip-XXXX.md
@@ -1,14 +1,14 @@
-| CHIP Number  |                                                                                 |
-| :----------- | :------------------------------------------------------------------------------ |
-| Title        | Split Royalties for NFT1                                                        |
-| Description  | A standard for splitting royalties for NFT1-compliant NFTs on Chia's blockchain |
-| Author       | [Andreas Greimel](https://github.com/greimela)                                  |
-| Comments-URI | < Creator must leave this blank. Editor will assign a URI.>                     |
-| Status       | < Creator must leave this blank. Editor will assign a status.>                  |
-| Category     | Process                                                                         |
-| Sub-Category | Procedural                                                                      |
-| Created      | 2022-09-03                                                                      |
-| Dependencies | None                                                                            |
+| CHIP Number  | < Creator must leave this blank. Editor will assign a number.>                                         |
+| :----------- | :----------------------------------------------------------------------------------------------------- |
+| Title        | Split Royalties for NFT1                                                                               |
+| Description  | A standard for splitting royalties for NFT1-compliant NFTs on Chia's blockchain                        |
+| Author       | [Andreas Greimel](https://github.com/greimela) ([@acevail\_](https://twitter.com/acevail_) on Twitter) |
+| Comments-URI | < Creator must leave this blank. Editor will assign a URI.>                                            |
+| Status       | < Creator must leave this blank. Editor will assign a status.>                                         |
+| Category     | Process                                                                                                |
+| Sub-Category | Procedural                                                                                             |
+| Created      | 2022-09-03                                                                                             |
+| Dependencies | None                                                                                                   |
 
 ## Abstract
 

--- a/CHIPs/chip-XXXX.md
+++ b/CHIPs/chip-XXXX.md
@@ -10,10 +10,6 @@
 | Created      | 2022-09-03                                                                      |
 | Dependencies | None                                                                            |
 
-<!-- This is the template for all CHIPs to use. Please fill it out according to the guidelines laid out in [chip001](/CHIPs/chip-0001.md). All media associated with this CHIP should be added to the `assets/chip-<CHIP>` folder, which you may create after you receive your CHIP number.
-
-Copy the template file to the `chips` folder, rename it to `chip-<your name>-<your proposal>`, fill it out, and submit it as a pull request. -->
-
 ## Abstract
 
 This proposal aims to define a standard for splitting royalties for NFT1-compliant NFTs, using a standard Chialisp puzzle to prevent marketplace lock-in.
@@ -23,16 +19,10 @@ This proposal aims to define a standard for splitting royalties for NFT1-complia
 One of the great features of NFT1 is the built-in payment of royalties.
 It is very flexible, since any address and therefore any puzzle can be used as royalty recipient.
 Many people in the community have requested the option to split the royalty payment between different recipients.
-Maybe a share should be sent to a Charity, or multiple artists want to share the royalties automatically.
+For example, a share should be sent to a charity, or multiple artists want to share the royalties automatically.
+Having this features available increases the value of the Chia NFT ecosystem as a whole.
 
-<!-- Describe why you are creating this proposal. Make sure to include:
-
-- What problem are you trying to solve?
-- How would this proposal benefit Chia's overall ecosystem?
-- What are the use cases for this proposal?
-- How technically feasible will this be to implement?
-
-This section is especially critical if you are proposing changes to Chia's core protocols. It should clearly answer all of the above, as well as explain exactly why the current protocol is inadequate. -->
+Due to the nature of the Coinset model, the royalty split has to be triggered by some off-chain entity. This proposal ensures to ensure independence from any individual actor.
 
 ## Backwards Compatibility
 
@@ -40,9 +30,15 @@ This proposal does not have any backwards incompatibilities.
 
 ## Rationale
 
-It is a simple Chialisp puzzle without many moving parts.
-The payment can not be altered by third parties.
-Anyone is able to trigger the royalty payout for any NFT -> marketplace independence
+There have already been approaches to split royalties in the Chia ecosystem. The shortcoming of the existing approaches is a dependence on a single actor to trigger the royalty split.
+
+The solution outlined in this propsal ensures independence from any single actor. This means that any observer of the Chia blockchain is able to trigger the royalty split, including the users wallet or an NFT marketplace.
+
+The core is a simple Chialisp puzzle without many moving parts. It includes a payout scheme defining how the royalty should be split. The payment scheme is fixed and can not be altered by third parties. Anyone is able to trigger the royalty payout for any NFT.
+
+In order to allow obervers to spend a royalty split coin, this proposal contains an extension to the NFT on-chain metadata to include the royalty payout scheme. This allows observers to recreate the royalty puzzle and optionally spend it.
+
+An alternative approach would be to include the royalty payout scheme in the off-chain metadata instead. This was dismissed since it would require an observer to fetch the off-chain metadata as well to be able to trigger the split, which increases the complexity and reduces the permanence. Relying solely on on-chain metadata ensures the royalty split can always be reconstructed.
 
 ## Specification
 
@@ -53,7 +49,7 @@ And an addition to the NFT metadata, to allow obervers to figure out the royalty
 An example payout scheme could look like this
 
 | Recipient Address                                              | Share in % |
-|:---------------------------------------------------------------|:-----------|
+| :------------------------------------------------------------- | :--------- |
 | xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsyuvkgj | 80         |
 | xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljnscmfrmx | 20         |
 
@@ -62,7 +58,7 @@ An example payout scheme could look like this
 The proposed Chialisp puzzle looks like this.
 
 ```
-(mod (ROYALTY_LIST my_amount)
+(mod (PAYOUT_SCHEME my_amount)
 
   (defconstant TEN_THOUSAND 10000)
 
@@ -73,24 +69,24 @@ The proposed Chialisp puzzle looks like this.
       (f (divmod (* amount percentage) TEN_THOUSAND))
   )
 
-  (defun-inline get_puzhash (royalty_list_item)
-      (f royalty_list_item)
+  (defun-inline get_amount (payout_scheme_item my_amount)
+      (calculate_percentage my_amount (f (r payout_scheme_item)))
   )
 
-  (defun-inline get_amount (royalty_list_item my_amount)
-      (calculate_percentage my_amount (f (r royalty_list_item)))
+  (defun-inline get_puzhash (payout_scheme_item)
+      (f payout_scheme_item)
   )
 
-   ; Loop through the royalty list and create coins
-  (defun split_amount_and_create_coins (ROYALTY_LIST my_amount)
-      (if ROYALTY_LIST
+   ; Loop through the royalty payout scheme and create coins
+  (defun split_amount_and_create_coins (PAYOUT_SCHEME my_amount)
+      (if PAYOUT_SCHEME
           (c
               (list
                 CREATE_COIN
-                (get_puzhash (f ROYALTY_LIST))
-                (get_amount (f ROYALTY_LIST) my_amount)
+                (get_puzhash (f PAYOUT_SCHEME))
+                (get_amount (f PAYOUT_SCHEME) my_amount)
               )
-              (split_amount_and_create_coins (r ROYALTY_LIST) my_amount)
+              (split_amount_and_create_coins (r PAYOUT_SCHEME) my_amount)
           )
           ()
       )
@@ -99,14 +95,18 @@ The proposed Chialisp puzzle looks like this.
   ; main
   (c
     (list ASSERT_MY_AMOUNT my_amount)
-    (split_amount_and_create_coins ROYALTY_LIST my_amount)
+    (split_amount_and_create_coins PAYOUT_SCHEME my_amount)
   )
 )
 ```
 
-The royalty payout scheme `ROYALTY_LIST` is curried into this puzzle, to make it immutable. The only solution parameter needed on spend is the actual amount of the coin.
+The royalty payout scheme `PAYOUT_SCHEME` is curried into this puzzle, to make it immutable. The only solution parameter needed on spend is the actual amount of the coin.
 
-On spend, the puzzle steps through the entries of the `ROYALTY_LIST` and creates a new coin per entry. The amount of the new coins will be a share of the total amount, determined by the share defined in the `ROYALTY_LIST`. The payout share is specified in the same format as NFT royalties, which is `int(percentage * 100)`.
+On spend, the puzzle steps through the entries of the `PAYOUT_SCHEME` and creates a new coin per entry. The amount of the new coins will be a share of the total amount, determined by the share defined in the `PAYOUT_SCHEME`. The payout share is specified in the same format as NFT royalties, which is `int(percentage * 100)`.
+
+If the created coins do not use up the full coin amount, the rest is left for the farmer of the block. This difference is most likely very small and not worth the effort to construct a more complex puzzle to collect this rest.
+
+The royalty puzzle does not check whether the shares in the payout table add up to 100%, since it would be too late. This verification has to be done by the entity creating the NFT and the payout scheme.
 
 ### NFT Metadata
 
@@ -117,7 +117,7 @@ The suggested format is a list of 2-tuples, each containing an address and the p
 
 ```typescript
 {
-  // [...existing metadata]
+  // existing metadata
   "rs": Array<[string, number]>
 }
 ```
@@ -134,34 +134,33 @@ The royalty payout example from above would look like this:
 }
 ```
 
+The wallet or tool accepting this payout scheme from a user and passing it into the NFT has to ensure the percentages add up to 100%.
+
 ## Test Cases
 
-- Most Standards Track proposals will require a suite of test cases, which you may add to the `assets/chip-<CHIP>` folder.
-- Some Process proposals will require test cases, depending on the significance of new features being added.
-- Informational proposals typically will not require test cases.
+The unit test for the royalty split Chialisp puzzle is located in the `royalty_split` branch of the `greimela/chia-blockchain` GitHub repository: [tests/wallet/nft_wallet/test_nft_puzzles.py](https://github.com/greimela/chia-blockchain/blob/royalty_split/tests/wallet/nft_wallet/test_nft_puzzles.py).
 
-Your proposal will have a greater chance of success if you err on the side of including more test cases. Use your best judgment.
+A more extensive integration test using NFT offers can be found here: [tests/wallet/nft_wallet/test_nft_royalty_split.clvm](https://github.com/greimela/chia-blockchain/blob/royalty_split/tests/wallet/nft_wallet/test_nft_royalty_split.py).
 
 ## Reference Implementation
 
-The reference implementation for Chia NFTs is located in the XXX branch of the chia-blockchain GitHub repository, under [chia/wallet/nft_wallet](TODO).
+The Chialisp puzzle itself is located in the `royalty_split` branch of the `greimela/chia-blockchain` GitHub repository: [chia/wallet/puzzles/royalty_split.clvm](https://github.com/greimela/chia-blockchain/blob/royalty_split/chia/wallet/puzzles/royalty_split.clvm).
 
 ## Security
 
 The Chialisp code has been covered by unit tests, but has not been audited yet by Chia Network or the broader community.
 
-Risks:
+Potential risks:
 
-- Royalties can be diverged
+- Royalty recipient can be altered
+  - The royalty recipients are curried into the puzzle and the only parameter in the solution is the amount. So the payout scheme can not be altered after it has been created.
 - Royalty payout can be stalled
+  - Since
 - Info to construct royalty puzzle can get lost
-
-<!-- This section is mandatory for all CHIPs. List all considerations relevant to the security of this proposal if it is implemented. This section may be modified as the proposal moves toward consensus. Make sure to include:
-
-- Security-related design decisions
-- Important discussions
-- Any security-related guidance
-- All threats and risks, as well as how you are addressing them -->
+  - The payout scheme is added to the NFT on-chain metadata, so it can not get lost as long as the Chia blockchain lives.
+- Users can be deceived by a mismatch between the NFT metadata and the actual royalty puzzle
+  - A malicious actor could specifiy in the NFT metadata that a large share of the royalties is given to some charity. The actor could then use a different royalty puzzle that sends all royalties to himself.
+  - Mitigation: Marketplaces and blockchain explorers should check whether the payout scheme defined in the NFT metadata matches the royalty puzzle.
 
 ## Additional Assets
 
@@ -170,7 +169,3 @@ No additional assets.
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-
-```
-
-```

--- a/CHIPs/chip-XXXX.md
+++ b/CHIPs/chip-XXXX.md
@@ -1,0 +1,175 @@
+| CHIP Number  |                                                                                 |
+| :----------- | :------------------------------------------------------------------------------ |
+| Title        | Split Royalties for NFT1                                                        |
+| Description  | A standard for splitting royalties for NFT1-compliant NFTs on Chia's blockchain |
+| Author       | [Andreas Greimel](https://github.com/greimela)                                  |
+| Comments-URI | < Creator must leave this blank. Editor will assign a URI.>                     |
+| Status       | < Creator must leave this blank. Editor will assign a status.>                  |
+| Category     | Process                                                                         |
+| Sub-Category | Procedural                                                                      |
+| Created      | 2022-09-03                                                                      |
+| Dependencies | None                                                                            |
+
+<!-- This is the template for all CHIPs to use. Please fill it out according to the guidelines laid out in [chip001](/CHIPs/chip-0001.md). All media associated with this CHIP should be added to the `assets/chip-<CHIP>` folder, which you may create after you receive your CHIP number.
+
+Copy the template file to the `chips` folder, rename it to `chip-<your name>-<your proposal>`, fill it out, and submit it as a pull request. -->
+
+## Abstract
+
+This proposal aims to define a standard for splitting royalties for NFT1-compliant NFTs, using a standard Chialisp puzzle to prevent marketplace lock-in.
+
+## Motivation
+
+One of the great features of NFT1 is the built-in payment of royalties.
+It is very flexible, since any address and therefore any puzzle can be used as royalty recipient.
+Many people in the community have requested the option to split the royalty payment between different recipients.
+Maybe a share should be sent to a Charity, or multiple artists want to share the royalties automatically.
+
+<!-- Describe why you are creating this proposal. Make sure to include:
+
+- What problem are you trying to solve?
+- How would this proposal benefit Chia's overall ecosystem?
+- What are the use cases for this proposal?
+- How technically feasible will this be to implement?
+
+This section is especially critical if you are proposing changes to Chia's core protocols. It should clearly answer all of the above, as well as explain exactly why the current protocol is inadequate. -->
+
+## Backwards Compatibility
+
+This proposal does not have any backwards incompatibilities.
+
+## Rationale
+
+It is a simple Chialisp puzzle without many moving parts.
+The payment can not be altered by third parties.
+Anyone is able to trigger the royalty payout for any NFT -> marketplace independence
+
+## Specification
+
+This specification has two parts.
+The Chialisp puzzle that splits itself into one or multiple smaller coins, according to a predefined payout scheme.
+And an addition to the NFT metadata, to allow obervers to figure out the royalty puzzle and optionally spend it.
+
+An example payout scheme could look like this
+
+| Recipient Address | Share in % |
+| xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsyuvkgj | 80 |
+| xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljnscmfrmx | 20 |
+
+### Royalty Split Chialisp Puzzle
+
+The proposed Chialisp puzzle looks like this.
+
+```
+(mod (ROYALTY_LIST my_amount)
+
+  (defconstant TEN_THOUSAND 10000)
+
+  (include condition_codes.clvm)
+  (include curry-and-treehash.clinc)
+
+  (defun-inline calculate_percentage (amount percentage)
+      (f (divmod (* amount percentage) TEN_THOUSAND))
+  )
+
+  (defun-inline get_puzhash (royalty_list_item)
+      (f royalty_list_item)
+  )
+
+  (defun-inline get_amount (royalty_list_item my_amount)
+      (calculate_percentage my_amount (f (r royalty_list_item)))
+  )
+
+   ; Loop through the royalty list and create coins
+  (defun split_amount_and_create_coins (ROYALTY_LIST my_amount)
+      (if ROYALTY_LIST
+          (c
+              (list
+                CREATE_COIN
+                (get_puzhash (f ROYALTY_LIST))
+                (get_amount (f ROYALTY_LIST) my_amount)
+              )
+              (split_amount_and_create_coins (r ROYALTY_LIST) my_amount)
+          )
+          ()
+      )
+  )
+
+  ; main
+  (c
+    (list ASSERT_MY_AMOUNT my_amount)
+    (split_amount_and_create_coins ROYALTY_LIST my_amount)
+  )
+)
+```
+
+The royalty payout scheme `ROYALTY_LIST` is curried into this puzzle, to make it immutable. The only solution parameter needed on spend is the actual amount of the coin.
+
+On spend, the puzzle steps through the entries of the `ROYALTY_LIST` and creates a new coin per entry. The amount of the new coins will be a share of the total amount, determined by the share defined in the `ROYALTY_LIST`.
+
+### NFT Metadata
+
+The second part is an addition to the NFT metadata.
+In order to allow any observer to recreate the split royalty puzzle and trigger the split, the observer has to know the payout scheme.
+
+The suggested format is a list of 2-tuples, each containing an address and the percentage of the royalties it should receive, multiplied by 100
+
+```typescript
+{
+  // [...existing metadata]
+  "rs": Array<[string, number]>
+}
+```
+
+The royalty payout example from above would look like this:
+
+```json
+{
+  //existing metadata
+  "rs": [
+    ["xch18qt2ju2sj3k8w3290az6flkkc95fqcmcg7edl90ns0jrjav8xttsyuvkgj", 8000], // 80%
+    ["xch1p9e3l3ttl7qrrhy6zmmqmjm0v33fvrxhd494yv7at0ppd97hljnscmfrmx", 2000] // 20%
+  ]
+}
+```
+
+## Test Cases
+
+- Most Standards Track proposals will require a suite of test cases, which you may add to the `assets/chip-<CHIP>` folder.
+- Some Process proposals will require test cases, depending on the significance of new features being added.
+- Informational proposals typically will not require test cases.
+
+Your proposal will have a greater chance of success if you err on the side of including more test cases. Use your best judgment.
+
+## Reference Implementation
+
+The reference implementation for Chia NFTs is located in the XXX branch of the chia-blockchain GitHub repository, under [chia/wallet/nft_wallet](TODO).
+
+## Security
+
+The Chialisp code has been covered by unit tests, but has not been audited yet by Chia Network or the broader community.
+
+Risks:
+
+- Royalties can be diverged
+- Royalty payout can be stalled
+- Info to construct royalty puzzle can get lost
+
+<!-- This section is mandatory for all CHIPs. List all considerations relevant to the security of this proposal if it is implemented. This section may be modified as the proposal moves toward consensus. Make sure to include:
+
+- Security-related design decisions
+- Important discussions
+- Any security-related guidance
+- All threats and risks, as well as how you are addressing them -->
+
+## Additional Assets
+
+No additional assets.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+```
+
+```


### PR DESCRIPTION
This proposal aims to define a standard for splitting royalties for NFT1-compliant NFTs, using a standard Chialisp puzzle to prevent marketplace lock-in.

The implementation of the Chialisp is already included, but it has not been audited by any third party yet.

Feedback is very welcome!