### PR TITLE
Capitalize CHIP-0001 reference in CHIP-0001

### DIFF
--- a/CHIPs/chip-0001.md
+++ b/CHIPs/chip-0001.md
@@ -209,7 +209,7 @@ If a CHIP with _Final_ status must be replaced, then it will be considered _Obso
 
 ### Living
 
-A small number of CHIPs will never be finalized because changes will occasionally need to be made. These CHIPs are considered _Living_, and include chip-0001.
+A small number of CHIPs will never be finalized because changes will occasionally need to be made. These CHIPs are considered _Living_, and include CHIP-0001.
 
 ---
 


### PR DESCRIPTION
https://github.com/Chia-Network/chips/blob/80e4611fe52b174bf1a0382b9dff73805b18b8c6/CHIPs/chip-0001.md#chip-numbers
> When referring to a CHIP by number, it should be written in the hyphenated form CHIP-WXYZ where WXYZ is the CHIP's assigned number.