### PR TITLE
Add CHIP-61 as a Draft to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The rest of this document is a summary of all notable CHIPs, organized by status
 * [55 - CATalog](https://github.com/Chia-Network/chips/pull/192)
 * [59 - Pooling v2](https://github.com/Chia-Network/chips/pull/203)
 * [60 - Titled CATs](https://github.com/Chia-Network/chips/pull/205)
+* [66 - Remote compact VDF proofs](https://github.com/Chia-Network/chips/pull/209)
 
 ### Review
 * [48 - New Proof of Space](https://github.com/Chia-Network/chips/pull/160)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only README index update with no runtime or protocol impact.
> 
> **Overview**
> Adds **CHIP-66 – Remote compact VDF proofs** to the **Draft** section of the CHIP index in `README.md`, linked to [chips PR #209](https://github.com/Chia-Network/chips/pull/209).
> 
> No proposal text or protocol behavior changes—only the public status list is updated so draft CHIP-66 appears alongside the other in-progress entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c208a58a73b3a77d24174cd03a3c1beff2e01c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->