### PR TITLE
Move CHIP-54 to Review in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The rest of this document is a summary of all notable CHIPs, organized by status
 * [1 - CHia Improvement Proposal (CHIP) process](/CHIPs/chip-0001.md)
 
 ### Draft
-* [54 - XCHandles](https://github.com/Chia-Network/chips/pull/192)
 * [55 - CATalog](https://github.com/Chia-Network/chips/pull/192)
 * [59 - Pooling v2](https://github.com/Chia-Network/chips/pull/203)
 * [60 - Titled CATs](https://github.com/Chia-Network/chips/pull/205)
@@ -22,6 +21,7 @@ The rest of this document is a summary of all notable CHIPs, organized by status
 * [49 - 3.0 Fork Info](https://github.com/Chia-Network/chips/pull/161)
 * [50 - Action Layer and Slots](https://github.com/Chia-Network/chips/pull/165)
 * [51 - Reward Distributor](https://github.com/Chia-Network/chips/pull/165)
+* [54 - XCHandles](https://github.com/Chia-Network/chips/pull/192)
 * [56 - Fee CATs](https://github.com/Chia-Network/chips/pull/194)
 * [57 - Silent Payments](https://github.com/Chia-Network/chips/pull/198)
 * [58 - Parallel Voting at Scale](https://github.com/Chia-Network/chips/pull/202)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only index update with no runtime or protocol impact.
> 
> **Overview**
> Updates the **README** CHIP index so **[54 - XCHandles](https://github.com/Chia-Network/chips/pull/192)** is listed under **Review** instead of **Draft**, reflecting its status change in the CHIP process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e88b9ef0c195a3eacf3762807107a22bb443160d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->