### PR TITLE
Update PR for CHIP-55

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The rest of this document is a summary of all notable CHIPs, organized by status
 * [1 - CHia Improvement Proposal (CHIP) process](/CHIPs/chip-0001.md)
 
 ### Draft
-* [55 - CATalog](https://github.com/Chia-Network/chips/pull/192)
+* [55 - CATalog](https://github.com/Chia-Network/chips/pull/212)
 * [59 - Pooling v2](https://github.com/Chia-Network/chips/pull/203)
 * [60 - Titled CATs](https://github.com/Chia-Network/chips/pull/205)
 * [61 - Remote compact VDF proofs](https://github.com/Chia-Network/chips/pull/209)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only README link change with no code or protocol impact.
> 
> **Overview**
> Updates the **Draft** CHIP list entry for **[55 - CATalog](https://github.com/Chia-Network/chips/pull/212)** so it links to GitHub PR **#212** instead of **#192**, matching the current proposal PR for CHIP-55.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd6fb02c32b6e2e3358de56b38b175c7d4882b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->