### PR TITLE
Add CHIPs 50, 51, and 54 to Last Call status in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ The rest of this document is a summary of all notable CHIPs, organized by status
 ### Review
 * [48 - New Proof of Space](https://github.com/Chia-Network/chips/pull/160)
 * [49 - 3.0 Fork Info](https://github.com/Chia-Network/chips/pull/161)
-* [50 - Action Layer and Slots](https://github.com/Chia-Network/chips/pull/165)
-* [51 - Reward Distributor](https://github.com/Chia-Network/chips/pull/165)
-* [54 - XCHandles](https://github.com/Chia-Network/chips/pull/192)
 * [56 - Fee CATs](https://github.com/Chia-Network/chips/pull/194)
 * [57 - Silent Payments](https://github.com/Chia-Network/chips/pull/198)
 * [58 - Parallel Voting at Scale](https://github.com/Chia-Network/chips/pull/202)
@@ -30,7 +27,9 @@ The rest of this document is a summary of all notable CHIPs, organized by status
 * None
 
 ### Last Call
-* None
+* [50 - Action Layer and Slots](https://github.com/Chia-Network/chips/pull/165)
+* [51 - Reward Distributor](https://github.com/Chia-Network/chips/pull/165)
+* [54 - XCHandles](https://github.com/Chia-Network/chips/pull/192)
 
 ### Final
 * [2 - dApp Protocol](/CHIPs/chip-0002.md)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only index update with no runtime or protocol implementation changes.
> 
> **Overview**
> Updates the **README** CHIP status index to reflect CHIP-1 workflow: **CHIP 50** (Action Layer and Slots), **CHIP 51** (Reward Distributor), and **CHIP 54** (XCHandles) are removed from **Review** and listed under **Last Call** (replacing the previous “None” entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2510001855af27267955b83f6531af5cf30d9bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->