### PR TITLE
Move CHIPs 50, 51, and 54 to Final in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ The rest of this document is a summary of all notable CHIPs, organized by status
 * None
 
 ### Last Call
-* [50 - Action Layer and Slots](https://github.com/Chia-Network/chips/pull/165)
-* [51 - Reward Distributor](https://github.com/Chia-Network/chips/pull/165)
-* [54 - XCHandles](https://github.com/Chia-Network/chips/pull/192)
+* None
 
 ### Final
 * [2 - dApp Protocol](/CHIPs/chip-0002.md)
@@ -65,7 +63,10 @@ The rest of this document is a summary of all notable CHIPs, organized by status
 * [44 - Clawback Standard v2](/CHIPs/chip-0044.md)
 * [45 - Options contracts](/CHIPs/chip-0045.md)
 * [47 - NFC Offer Data](/CHIPs/chip-0047.md)
+* [50 - Action Layer and Slots](/CHIPs/chip-0050.md)
+* [51 - Reward Distributor](/CHIPs/chip-0051.md)
 * [52 - Partial Offers](/CHIPs/chip-0052.md)
+* [54 - XCHandles](/CHIPs/chip-0054.md)
 
 ### Stagnant
 * [16 - VC1 standard](https://github.com/Chia-Network/chips/pull/65)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only status list update in README with no code or process logic changes.
> 
> **Overview**
> Updates the **README** CHIP index to reflect that **CHIP-50** (Action Layer and Slots), **CHIP-51** (Reward Distributor), and **CHIP-54** (XCHandles) have reached **Final** status.
> 
> Those three entries are removed from **Last Call** (that section is now empty) and added under **Final** with links to `/CHIPs/chip-0050.md`, `chip-0051.md`, and `chip-0054.md` instead of open PR URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cad040d675e1cf2b9ce014a19bd1ae1eb148546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->