### PR TITLE
Add CHIP-62 as a Draft to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The rest of this document is a summary of all notable CHIPs, organized by status
 * [59 - Pooling v2](https://github.com/Chia-Network/chips/pull/203)
 * [60 - Titled CATs](https://github.com/Chia-Network/chips/pull/205)
 * [61 - Remote compact VDF proofs](https://github.com/Chia-Network/chips/pull/209)
+* [62 - The Forge: Weighted N-Asset AMM](https://github.com/Chia-Network/chips/pull/217)
 
 ### Review
 * [48 - New Proof of Space](https://github.com/Chia-Network/chips/pull/160)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single README index entry with no protocol or implementation changes in this diff.
> 
> **Overview**
> Adds **CHIP-62** (*The Forge: Weighted N-Asset AMM*) to the **Draft** section of the CHIP index in `README.md`, with a link to [PR #217](https://github.com/Chia-Network/chips/pull/217).
> 
> This is a documentation-only update to keep the public CHIP status list in sync when CHIP-62 enters Draft.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa95bca7d9a74b8d256658481e6045da63737bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->